### PR TITLE
feat(auth): Add MSAL authentication, UI fixes, CI tweaks, docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,25 +2,92 @@
 
 [![CI](https://github.com/smereczynski/AzKview/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/smereczynski/AzKview/actions/workflows/ci.yml)
 
-Cross-platform Avalonia UI application (net9.0) using MVVM and clean solution structure.
+Cross‑platform desktop app built with Avalonia UI (net9.0), MVVM, and a clean multi‑project layout. It includes Azure AD authentication via MSAL.NET with platform‑aware UX (Windows WAM, macOS system web session).
 
-## Structure
-- `src/AzKview.App`: Desktop entry point (Avalonia App), references Core and UI.
-- `src/AzKview.Core`: Domain/services.
-- `src/AzKview.UI`: Reusable controls/views/resources.
-- `tests/AzKview.Core.Tests`: xUnit tests for Core.
+## Project map
 
-## Prerequisites
-- .NET SDK 9.0+
-- Avalonia templates (installed via `dotnet new install Avalonia.Templates`)
+Top‑level layout:
 
-## Build & Run
-- Build solution:
-  - `dotnet build`
-- Run app:
-  - `dotnet run --project src/AzKview.App`
-- Run tests:
-  - `dotnet test`
+- `src/`
+  - `AzKview.App/` — Desktop application (Avalonia)
+    - `App.axaml` / `App.axaml.cs` — App resources/bootstrap; reads env vars and wires services
+    - `Program.cs` — Avalonia bootstrapping (UsePlatformDetect, Inter font, logging)
+    - `Services/`
+      - `AuthService.cs` — MSAL.NET auth: token cache, Windows WAM, macOS system web, logging
+    - `ViewModels/`
+      - `MainWindowViewModel.cs` — Greeting from time service; Sign in/out commands and state
+      - `ViewModelBase.cs` — ObservableObject base
+    - `Views/`
+      - `MainWindow.axaml` / `.cs` — Main UI with Sign in/out and UPN display
+    - `ViewLocator.cs` — ViewModel→View resolution by naming convention
+  - `AzKview.Core/` — Core abstractions and services (UI‑free)
+    - `Services/`
+      - `IAuthService.cs` — Auth abstraction (UPN, state, events, token acquisition)
+      - `TimeService.cs` — Time provider (UTC now) for testability
+  - `AzKview.UI/` — Placeholder for reusable UI components
+- `tests/`
+  - `AzKview.Core.Tests/` — xUnit tests (TimeService)
 
-## Git
-This repo is structured for clean CI and PRs. Use feature branches and conventional commits.
+## Authentication
+
+MSAL.NET Public Client Application configured at runtime:
+
+- Windows: WAM broker for native account picker and SSO, redirect URI:
+  - `ms-appx-web://microsoft.aad.brokerplugin/{CLIENT_ID}`
+- macOS: System web authentication session (ASWebAuthenticationSession), redirect URI:
+  - `http://localhost`
+
+Token cache is persisted securely via `Microsoft.Identity.Client.Extensions.Msal` (Keychain/Keyring).
+
+### Env vars
+
+Set before launching the app:
+
+- `AZURE_AD_CLIENT_ID` — App registration (application) ID
+- `AZURE_AD_TENANT_ID` — Tenant ID or alias (e.g., `common`)
+- `AZURE_AD_SCOPES` — Space/comma/semicolon‑separated scopes (default: `User.Read`)
+- `AZURE_AD_LOG_MSAL` — `true` to enable verbose MSAL logs to console (default: `false`)
+- `AZURE_AD_LOG_PII` — `true` to include PII in logs (default: `false`; use only for local debugging)
+
+Example (macOS zsh):
+
+```sh
+export AZURE_AD_CLIENT_ID="<app-id>"
+export AZURE_AD_TENANT_ID="<tenant-id-or-common>"
+export AZURE_AD_SCOPES="User.Read offline_access openid profile"
+export AZURE_AD_LOG_MSAL=true
+export AZURE_AD_LOG_PII=false
+dotnet run --project src/AzKview.App/AzKview.App.csproj
+```
+
+## Build, run, and test
+
+```sh
+# Build entire solution
+dotnet build
+
+# Run the desktop app
+dotnet run --project src/AzKview.App
+
+# Run unit tests
+dotnet test
+```
+
+## CI
+
+GitHub Actions builds and tests on Windows and macOS. Workflows are under `.github/workflows` and are permitted via `.gitignore` whitelist.
+
+## Troubleshooting
+
+- Sign in button disabled
+  - The button enablement is driven by command CanExecute; ensure the app started and ViewModel loaded.
+- Browser opens but sign in fails on macOS
+  - Confirm the app registration has the `http://localhost` redirect URI.
+- WAM broker fails on Windows
+  - Confirm the broker redirect URI is configured and the broker (WAM) is available on the machine.
+- Need more auth diagnostics
+  - Set `AZURE_AD_LOG_MSAL=true` (and optionally `AZURE_AD_LOG_PII=true`) before launch.
+
+## Contributing
+
+Use feature branches and conventional commits. Open PRs against `main`. The repository enforces CI and simple test coverage.

--- a/src/AzKview.App/App.axaml.cs
+++ b/src/AzKview.App/App.axaml.cs
@@ -6,6 +6,8 @@ using System.Linq;
 using Avalonia.Markup.Xaml;
 using AzKview.App.ViewModels;
 using AzKview.App.Views;
+using AzKview.App.Services;
+using AzKview.Core.Services;
 
 namespace AzKview.App;
 
@@ -23,9 +25,15 @@ public partial class App : Application
             // Avoid duplicate validations from both Avalonia and the CommunityToolkit. 
             // More info: https://docs.avaloniaui.net/docs/guides/development-guides/data-validation#manage-validationplugins
             DisableAvaloniaDataAnnotationValidation();
+            var clientId = Environment.GetEnvironmentVariable("AZURE_AD_CLIENT_ID") ?? "YOUR_CLIENT_ID";
+            var tenantId = Environment.GetEnvironmentVariable("AZURE_AD_TENANT_ID") ?? "common";
+            var defaultScopes = new[] { "User.Read" };
+
+            IAuthService authService = new AuthService(clientId, tenantId, defaultScopes);
+
             desktop.MainWindow = new MainWindow
             {
-                DataContext = new MainWindowViewModel(),
+                DataContext = new MainWindowViewModel(new TimeService(), authService),
             };
         }
 

--- a/src/AzKview.App/App.axaml.cs
+++ b/src/AzKview.App/App.axaml.cs
@@ -27,7 +27,13 @@ public partial class App : Application
             DisableAvaloniaDataAnnotationValidation();
             var clientId = Environment.GetEnvironmentVariable("AZURE_AD_CLIENT_ID") ?? "YOUR_CLIENT_ID";
             var tenantId = Environment.GetEnvironmentVariable("AZURE_AD_TENANT_ID") ?? "common";
-            var defaultScopes = new[] { "User.Read" };
+            var scopesEnv = Environment.GetEnvironmentVariable("AZURE_AD_SCOPES");
+            var defaultScopes = string.IsNullOrWhiteSpace(scopesEnv)
+                ? new[] { "User.Read" }
+                : scopesEnv
+                    .Split(new[] { ',', ';', ' ' }, StringSplitOptions.RemoveEmptyEntries)
+                    .Select(s => s.Trim())
+                    .ToArray();
 
             IAuthService authService = new AuthService(clientId, tenantId, defaultScopes);
 

--- a/src/AzKview.App/AzKview.App.csproj
+++ b/src/AzKview.App/AzKview.App.csproj
@@ -27,6 +27,9 @@
     </PackageReference>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />
   <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+  <PackageReference Include="Microsoft.Identity.Client" Version="4.66.1" />
+  <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.56.0" />
+  <PackageReference Include="Microsoft.Identity.Client.Broker" Version="4.66.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AzKview.App/Services/AuthService.cs
+++ b/src/AzKview.App/Services/AuthService.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using AzKview.Core.Services;
+using Microsoft.Identity.Client;
+using Microsoft.Identity.Client.Extensions.Msal;
+using Microsoft.Identity.Client.Broker;
+
+namespace AzKview.App.Services;
+
+public class AuthService : IAuthService
+{
+    private readonly string _clientId;
+    private readonly string _tenantId;
+    private readonly string[] _defaultScopes;
+    private readonly IPublicClientApplication _pca;
+    private IAccount? _account;
+
+    public AuthService(string clientId, string tenantId, string[] defaultScopes)
+    {
+        _clientId = clientId;
+        _tenantId = tenantId;
+        _defaultScopes = defaultScopes;
+
+        var builder = PublicClientApplicationBuilder
+            .Create(_clientId)
+            .WithAuthority(AzureCloudInstance.AzurePublic, _tenantId)
+            .WithRedirectUri(GetRedirectUri(_clientId));
+
+        // Windows: enable WAM broker for native account picker & SSO
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            builder = builder.WithBroker(new BrokerOptions(BrokerOptions.OperatingSystems.Windows));
+        }
+
+        _pca = builder.Build();
+
+        // Cross-platform secure token cache
+        var storageProps = new StorageCreationPropertiesBuilder(
+                cacheFileName: "msal_cache.dat",
+                cacheDirectory: MsalCacheHelper.UserRootDirectory)
+            .WithLinuxKeyring(
+                schemaName: "com.azkview.tokencache",
+                collection: "default",
+                secretLabel: "AzKview MSAL token cache",
+                attribute1: new KeyValuePair<string, string>("Version", "1"),
+                attribute2: new KeyValuePair<string, string>("ProductName", "AzKview"))
+            .WithMacKeyChain(
+                serviceName: "com.azkview.tokencache",
+                accountName: "AzKview")
+            .Build();
+
+        var cacheHelper = MsalCacheHelper.CreateAsync(storageProps).GetAwaiter().GetResult();
+        cacheHelper.RegisterCache(_pca.UserTokenCache);
+    }
+
+    public string? AccountUpn => _account?.Username;
+    public bool IsAuthenticated => _account != null;
+
+    public event EventHandler<bool>? AuthenticationStateChanged;
+
+    public async Task<bool> SignInAsync()
+    {
+        try
+        {
+            var accounts = await _pca.GetAccountsAsync().ConfigureAwait(false);
+            _account = accounts.FirstOrDefault();
+
+            try
+            {
+                // Try silent first
+                var silent = await _pca.AcquireTokenSilent(_defaultScopes, _account)
+                    .ExecuteAsync().ConfigureAwait(false);
+                _account = silent.Account;
+            }
+            catch (MsalUiRequiredException)
+            {
+                var interactiveBuilder = _pca.AcquireTokenInteractive(_defaultScopes)
+                    .WithPrompt(Prompt.SelectAccount);
+
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                {
+                    // For macOS, MSAL uses system browser by default. Provide parent window handle if needed.
+                    interactiveBuilder = interactiveBuilder.WithSystemWebViewOptions(new SystemWebViewOptions
+                    {
+                        // Leave defaults; on macOS it uses ASWebAuthenticationSession under the hood when available
+                    });
+                }
+
+                var interactive = await interactiveBuilder.ExecuteAsync().ConfigureAwait(false);
+                _account = interactive.Account;
+            }
+
+            AuthenticationStateChanged?.Invoke(this, true);
+            return true;
+        }
+        catch (Exception)
+        {
+            AuthenticationStateChanged?.Invoke(this, false);
+            return false;
+        }
+    }
+
+    public async Task SignOutAsync()
+    {
+        var accounts = await _pca.GetAccountsAsync().ConfigureAwait(false);
+        foreach (var acc in accounts)
+        {
+            await _pca.RemoveAsync(acc).ConfigureAwait(false);
+        }
+        _account = null;
+        AuthenticationStateChanged?.Invoke(this, false);
+    }
+
+    public async Task<string?> AcquireTokenAsync(string[] scopes)
+    {
+        try
+        {
+            if (_account is null)
+            {
+                var ok = await SignInAsync().ConfigureAwait(false);
+                if (!ok) return null;
+            }
+
+            try
+            {
+                var silent = await _pca.AcquireTokenSilent(scopes, _account)
+                    .ExecuteAsync().ConfigureAwait(false);
+                return silent.AccessToken;
+            }
+            catch (MsalUiRequiredException)
+            {
+                var interactive = await _pca.AcquireTokenInteractive(scopes)
+                    .WithPrompt(Prompt.SelectAccount)
+                    .ExecuteAsync().ConfigureAwait(false);
+                _account = interactive.Account;
+                return interactive.AccessToken;
+            }
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static string GetRedirectUri(string clientId)
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            // WAM broker redirect
+            return $"ms-appx-web://microsoft.aad.brokerplugin/{clientId}";
+        }
+
+        // Use loopback for desktop on macOS
+        return "http://localhost";
+    }
+}

--- a/src/AzKview.App/Services/AuthService.cs
+++ b/src/AzKview.App/Services/AuthService.cs
@@ -34,6 +34,22 @@ public class AuthService : IAuthService
             builder = builder.WithBroker(new BrokerOptions(BrokerOptions.OperatingSystems.Windows));
         }
 
+        // Optional MSAL logging controlled by environment variables
+        var enableMsalLogging = (Environment.GetEnvironmentVariable("AZURE_AD_LOG_MSAL") ?? "false").Equals("true", StringComparison.OrdinalIgnoreCase);
+        var enablePii = (Environment.GetEnvironmentVariable("AZURE_AD_LOG_PII") ?? "false").Equals("true", StringComparison.OrdinalIgnoreCase);
+        if (enableMsalLogging)
+        {
+            builder = builder.WithLogging((level, message, containsPii) =>
+            {
+                // Write to console; VS Code Debug Console will show this when running
+                var tag = containsPii ? "[MSAL-PII]" : "[MSAL]";
+                Console.WriteLine($"{tag} {level}: {message}");
+            },
+            LogLevel.Verbose,
+            enablePii,
+            enableDefaultPlatformLogging: false);
+        }
+
         _pca = builder.Build();
 
         // Cross-platform secure token cache

--- a/src/AzKview.App/ViewModels/MainWindowViewModel.cs
+++ b/src/AzKview.App/ViewModels/MainWindowViewModel.cs
@@ -49,6 +49,16 @@ file sealed class NullAuthService : IAuthService
     public bool IsAuthenticated => false;
     public event EventHandler<bool>? AuthenticationStateChanged;
     public Task<string?> AcquireTokenAsync(string[] scopes) => Task.FromResult<string?>(null);
-    public Task<bool> SignInAsync() => Task.FromResult(false);
-    public Task SignOutAsync() => Task.CompletedTask;
+    public Task<bool> SignInAsync()
+    {
+        // Notify listeners even though auth state doesn't change in the null implementation.
+        AuthenticationStateChanged?.Invoke(this, IsAuthenticated);
+        return Task.FromResult(false);
+    }
+    public Task SignOutAsync()
+    {
+        // Notify listeners to indicate an attempted sign-out occurred.
+        AuthenticationStateChanged?.Invoke(this, IsAuthenticated);
+        return Task.CompletedTask;
+    }
 }

--- a/src/AzKview.App/ViewModels/MainWindowViewModel.cs
+++ b/src/AzKview.App/ViewModels/MainWindowViewModel.cs
@@ -1,15 +1,54 @@
 ﻿using AzKview.Core.Services;
+using CommunityToolkit.Mvvm.Input;
+using System.Threading.Tasks;
 
 namespace AzKview.App.ViewModels;
 
 public partial class MainWindowViewModel : ViewModelBase
 {
-    public MainWindowViewModel() : this(new TimeService()) { }
+    private readonly IAuthService _authService;
+    
+    public MainWindowViewModel() : this(new TimeService(), null!) { }
 
-    public MainWindowViewModel(ITimeService timeService)
+    public MainWindowViewModel(ITimeService timeService, IAuthService authService)
     {
+        _authService = authService ?? new NullAuthService();
         Greeting = $"Welcome to Avalonia! UTC: {timeService.UtcNow:O}";
+        _authService.AuthenticationStateChanged += (_, __) =>
+        {
+            OnPropertyChanged(nameof(IsAuthenticated));
+            OnPropertyChanged(nameof(AccountUpn));
+        };
     }
 
     public string Greeting { get; }
+
+    public bool IsAuthenticated => _authService.IsAuthenticated;
+    public string? AccountUpn => _authService.AccountUpn;
+
+    [RelayCommand]
+    private async Task SignInAsync()
+    {
+        await _authService.SignInAsync();
+        OnPropertyChanged(nameof(IsAuthenticated));
+        OnPropertyChanged(nameof(AccountUpn));
+    }
+
+    [RelayCommand]
+    private async Task SignOutAsync()
+    {
+        await _authService.SignOutAsync();
+        OnPropertyChanged(nameof(IsAuthenticated));
+        OnPropertyChanged(nameof(AccountUpn));
+    }
+}
+
+file sealed class NullAuthService : IAuthService
+{
+    public string? AccountUpn => null;
+    public bool IsAuthenticated => false;
+    public event EventHandler<bool>? AuthenticationStateChanged;
+    public Task<string?> AcquireTokenAsync(string[] scopes) => Task.FromResult<string?>(null);
+    public Task<bool> SignInAsync() => Task.FromResult(false);
+    public Task SignOutAsync() => Task.CompletedTask;
 }

--- a/src/AzKview.App/ViewModels/MainWindowViewModel.cs
+++ b/src/AzKview.App/ViewModels/MainWindowViewModel.cs
@@ -18,6 +18,8 @@ public partial class MainWindowViewModel : ViewModelBase
         {
             OnPropertyChanged(nameof(IsAuthenticated));
             OnPropertyChanged(nameof(AccountUpn));
+            (SignInCommand as IRelayCommand)?.NotifyCanExecuteChanged();
+            (SignOutCommand as IRelayCommand)?.NotifyCanExecuteChanged();
         };
     }
 
@@ -26,20 +28,28 @@ public partial class MainWindowViewModel : ViewModelBase
     public bool IsAuthenticated => _authService.IsAuthenticated;
     public string? AccountUpn => _authService.AccountUpn;
 
-    [RelayCommand]
+    private bool CanSignIn() => !_authService.IsAuthenticated;
+
+    [RelayCommand(CanExecute = nameof(CanSignIn))]
     private async Task SignInAsync()
     {
         await _authService.SignInAsync();
         OnPropertyChanged(nameof(IsAuthenticated));
         OnPropertyChanged(nameof(AccountUpn));
+        (SignInCommand as IRelayCommand)?.NotifyCanExecuteChanged();
+        (SignOutCommand as IRelayCommand)?.NotifyCanExecuteChanged();
     }
 
-    [RelayCommand]
+    private bool CanSignOut() => _authService.IsAuthenticated;
+
+    [RelayCommand(CanExecute = nameof(CanSignOut))]
     private async Task SignOutAsync()
     {
         await _authService.SignOutAsync();
         OnPropertyChanged(nameof(IsAuthenticated));
         OnPropertyChanged(nameof(AccountUpn));
+        (SignInCommand as IRelayCommand)?.NotifyCanExecuteChanged();
+        (SignOutCommand as IRelayCommand)?.NotifyCanExecuteChanged();
     }
 }
 

--- a/src/AzKview.App/Views/MainWindow.axaml
+++ b/src/AzKview.App/Views/MainWindow.axaml
@@ -18,8 +18,8 @@
     <StackPanel Spacing="12" Margin="16">
         <TextBlock Text="{Binding Greeting}" HorizontalAlignment="Center"/>
         <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center">
-            <Button Content="Sign in" Command="{Binding SignInCommand}" IsEnabled="{Binding IsAuthenticated, ConverterParameter=False}"/>
-            <Button Content="Sign out" Command="{Binding SignOutCommand}" IsEnabled="{Binding IsAuthenticated}"/>
+            <Button Content="Sign in" Command="{Binding SignInCommand}"/>
+            <Button Content="Sign out" Command="{Binding SignOutCommand}"/>
         </StackPanel>
         <TextBlock Text="{Binding AccountUpn, StringFormat='User: {0}'}" HorizontalAlignment="Center"/>
     </StackPanel>

--- a/src/AzKview.App/Views/MainWindow.axaml
+++ b/src/AzKview.App/Views/MainWindow.axaml
@@ -15,6 +15,13 @@
         <vm:MainWindowViewModel/>
     </Design.DataContext>
 
-    <TextBlock Text="{Binding Greeting}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+    <StackPanel Spacing="12" Margin="16">
+        <TextBlock Text="{Binding Greeting}" HorizontalAlignment="Center"/>
+        <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center">
+            <Button Content="Sign in" Command="{Binding SignInCommand}" IsEnabled="{Binding IsAuthenticated, ConverterParameter=False}"/>
+            <Button Content="Sign out" Command="{Binding SignOutCommand}" IsEnabled="{Binding IsAuthenticated}"/>
+        </StackPanel>
+        <TextBlock Text="{Binding AccountUpn, StringFormat='User: {0}'}" HorizontalAlignment="Center"/>
+    </StackPanel>
 
 </Window>

--- a/src/AzKview.Core/Services/IAuthService.cs
+++ b/src/AzKview.Core/Services/IAuthService.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Threading.Tasks;
+
+namespace AzKview.Core.Services;
+
+public interface IAuthService
+{
+    string? AccountUpn { get; }
+    bool IsAuthenticated { get; }
+
+    Task<bool> SignInAsync();
+    Task SignOutAsync();
+    Task<string?> AcquireTokenAsync(string[] scopes);
+
+    event EventHandler<bool>? AuthenticationStateChanged;
+}


### PR DESCRIPTION
Adds cross-platform authentication via MSAL.NET (WAM on Windows, system web session on macOS), secure token cache, MVVM command enablement, UI thread dispatching fixes, env-driven scopes & optional MSAL logging. Updates CI to run on windows-latest and macos-15 with explicit permissions and artifacts. Documents project structure and auth setup in README. All projects build and tests pass locally.